### PR TITLE
Changed the limited size for an entry in "last entrys" (Pastebin goes responsive...)

### DIFF
--- a/controller/main.php
+++ b/controller/main.php
@@ -174,7 +174,6 @@ class main
 				'DESC'			=> $row['snippet_desc'],
 				'TITLE'			=> $row['snippet_title'],
 				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 50) ? utf8_substr($row['snippet_title'], 0, 50) . '...' : $row['snippet_title'],
-				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 50) ? utf8_substr($row['snippet_title'], 0, 50) . '...' : $row['snippet_title'],
 				'AUTHOR_FULL'	=> get_username_string('full', $row['user_id'], $row['username'], $row['user_colour']),
 			));
 		}

--- a/controller/main.php
+++ b/controller/main.php
@@ -173,7 +173,8 @@ class main
 				'URL'			=> $this->helper->route('phpbbde_pastebin_main_controller', array('mode'=>'view', 's' => $row['snippet_id'])),
 				'DESC'			=> $row['snippet_desc'],
 				'TITLE'			=> $row['snippet_title'],
-				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 60) ? utf8_substr($row['snippet_title'], 0, 60) . '...' : $row['snippet_title'],
+				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 50) ? utf8_substr($row['snippet_title'], 0, 50) . '...' : $row['snippet_title'],
+				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 50) ? utf8_substr($row['snippet_title'], 0, 50) . '...' : $row['snippet_title'],
 				'AUTHOR_FULL'	=> get_username_string('full', $row['user_id'], $row['username'], $row['user_colour']),
 			));
 		}

--- a/controller/main.php
+++ b/controller/main.php
@@ -173,7 +173,7 @@ class main
 				'URL'			=> $this->helper->route('phpbbde_pastebin_main_controller', array('mode'=>'view', 's' => $row['snippet_id'])),
 				'DESC'			=> $row['snippet_desc'],
 				'TITLE'			=> $row['snippet_title'],
-				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 12) ? utf8_substr($row['snippet_title'], 0, 12) . '...' : $row['snippet_title'],
+				'TITLE_SHORT'	=> (utf8_strlen($row['snippet_title']) > 60) ? utf8_substr($row['snippet_title'], 0, 60) . '...' : $row['snippet_title'],
 				'AUTHOR_FULL'	=> get_username_string('full', $row['user_id'], $row['username'], $row['user_colour']),
 			));
 		}


### PR DESCRIPTION
As a part of the design adjustment for mobile devices, I changed the display size for the "last entry" section in the bottom of the pastebin-page. The size is no longer limited to only 12 characters (old design) - now it is limited to 50 chars.

Fixes #15 
